### PR TITLE
Update name of lock file

### DIFF
--- a/get-started/deploy.qmd
+++ b/get-started/deploy.qmd
@@ -155,7 +155,7 @@ docker_contents <- gsub(paste0(docker_dir, "/"), "", docker_contents, fixed = TR
 cat(docker_contents, sep = "\n")
 ```
 
-When you run `vetiver_write_docker()`, you generate *two* files: the Dockerfile itself and [the `renv.lock` file](https://rstudio.github.io/renv/articles/lockfile.html) to capture your model dependencies.
+When you run `vetiver_write_docker()`, you generate *two* files: the Dockerfile itself and [the `vetiver_renv.lock` file](https://rstudio.github.io/renv/articles/lockfile.html) to capture your model dependencies.
 
 ## Python
 


### PR DESCRIPTION
As of [vetiver 0.1.6](https://github.com/rstudio/vetiver-r/blob/main/NEWS.md#vetiver-016) the default name of the lock file changed.