### PR TITLE
Adding drop ptype_data to Python example

### DIFF
--- a/get-started/version.qmd
+++ b/get-started/version.qmd
@@ -33,9 +33,9 @@ from vetiver import VetiverModel
 from sklearn import linear_model
 
 car_mod = linear_model.LinearRegression().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
-
+                 
 v = VetiverModel(car_mod, model_name = "cars_mpg", 
-                 save_ptype = True, ptype_data = mtcars)
+                 save_ptype = True, ptype_data = mtcars.drop(columns="mpg"))
 ```
 :::
 


### PR DESCRIPTION
The following code:
```{python}
v = VetiverModel(car_mod, model_name = "cars_mpg", 
                 save_ptype = True, ptype_data = mtcars.drop(columns="mpg"))
```
exists under Deploy -> Python -> Review of previous steps (https://vetiver.rstudio.com/get-started/deploy.html) but does not exist under Version -> Python -> Store and version your model (second code block under the headline). 

This PR merely corrects that.