### PR TITLE
Remove `save_ptype` argument

### DIFF
--- a/get-started/deploy.qmd
+++ b/get-started/deploy.qmd
@@ -41,7 +41,7 @@ from pins import board_folder
 car_mod = tree.DecisionTreeRegressor().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
 
 v = VetiverModel(car_mod, model_name = "cars_mpg", 
-                 save_ptype = True, ptype_data = mtcars.drop(columns="mpg"))
+                 ptype_data = mtcars.drop(columns="mpg"))
 
 model_board = board_folder("pins-py", allow_pickle_read=True)
 vetiver_pin_write(model_board, v)

--- a/get-started/index.qmd
+++ b/get-started/index.qmd
@@ -86,9 +86,9 @@ Let's consider one kind of model supported by vetiver, a [scikit-learn](https://
 
 ```{python}
 from vetiver.data import mtcars
-from sklearn import linear_model
+from sklearn.linear_model import LinearRegression
 
-car_mod = linear_model.LinearRegression().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
+car_mod = LinearRegression().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
 ```
 :::
 
@@ -113,7 +113,7 @@ v
 ```{python}
 from vetiver import VetiverModel
 v = VetiverModel(car_mod, model_name = "cars_mpg", 
-                 save_ptype = True, ptype_data = mtcars)
+                 ptype_data = mtcars.drop(columns="mpg"))
 v.description
 ```
 :::

--- a/get-started/version.qmd
+++ b/get-started/version.qmd
@@ -35,7 +35,7 @@ from sklearn import linear_model
 car_mod = linear_model.LinearRegression().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
                  
 v = VetiverModel(car_mod, model_name = "cars_mpg", 
-                 save_ptype = True, ptype_data = mtcars.drop(columns="mpg"))
+                 ptype_data = mtcars.drop(columns="mpg"))
 ```
 :::
 
@@ -101,7 +101,7 @@ from sklearn import tree
 car_mod = tree.DecisionTreeRegressor().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
 
 v = VetiverModel(car_mod, model_name = "cars_mpg", 
-                 save_ptype = True, ptype_data = mtcars)
+                 ptype_data = mtcars.drop(columns="mpg"))
 vetiver_pin_write(model_board, v)
 ```
 :::

--- a/index.qmd
+++ b/index.qmd
@@ -45,11 +45,11 @@ vetiver_model(cars_lm, "cars_linear")
 ```{python}
 from vetiver import VetiverModel
 from vetiver.data import mtcars
-from sklearn import linear_model
+from sklearn.linear_model import LinearRegression
 
-model = linear_model.LinearRegression().fit(mtcars, mtcars["mpg"])
+model = LinearRegression().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
 v = VetiverModel(model, model_name = "cars_linear", 
-                 save_ptype = True, ptype_data = mtcars)
+                 ptype_data = mtcars.drop(columns="mpg"))
 v.description
 ```
 :::

--- a/learn-more/model-card.qmd
+++ b/learn-more/model-card.qmd
@@ -40,7 +40,7 @@ from sklearn.linear_model import LinearRegression
 
 model_board = pins.board_temp(allow_pickle_read=True)
 
-model = LinearRegression().fit(mtcars, mtcars["mpg"])
+model = LinearRegression().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
 v = vetiver.VetiverModel(model, model_name = "cars_linear", 
                  ptype_data = mtcars.drop(columns="mpg"))
 

--- a/learn-more/model-card.qmd
+++ b/learn-more/model-card.qmd
@@ -42,7 +42,7 @@ model_board = pins.board_temp(allow_pickle_read=True)
 
 model = LinearRegression().fit(mtcars, mtcars["mpg"])
 v = vetiver.VetiverModel(model, model_name = "cars_linear", 
-                 save_ptype = True, ptype_data = mtcars)
+                 ptype_data = mtcars.drop(columns="mpg"))
 
 vetiver.vetiver_pin_write(model_board, v)
 ```


### PR DESCRIPTION
closes #47 

Removing the `save_ptype` argument. 
Some light rearranging of imports for better readability. 
Making sure mtcars models are not training with the mpg column.