### PR TITLE
Updates for vetiver 0.2.0

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,1 +1,3 @@
 ^\.github$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/get-started/deploy.qmd
+++ b/get-started/deploy.qmd
@@ -41,7 +41,7 @@ from pins import board_folder
 car_mod = tree.DecisionTreeRegressor().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
 
 v = VetiverModel(car_mod, model_name = "cars_mpg", 
-                 ptype_data = mtcars.drop(columns="mpg"))
+                 prototype_data = mtcars.drop(columns="mpg"))
 
 model_board = board_folder("pins-py", allow_pickle_read=True)
 vetiver_pin_write(model_board, v)

--- a/get-started/deploy.qmd
+++ b/get-started/deploy.qmd
@@ -98,14 +98,12 @@ vetiver_deploy_rsconnect(model_board, "user.name/cars_mpg")
 
 ```{python}
 #| eval: false
-import os
-from dotenv import load_dotenv, find_dotenv
 import rsconnect
 
-load_dotenv(find_dotenv())
-rsc_key = os.getenv("API_KEY")
-rsc_url = os.getenv("RSC_URL")
-connect_server = RSConnectServer(url = rsc_url, api_key = rsc_key)
+connect_server = RSConnectServer(
+    url=server_url, # load from an .env file
+    api_key=api_key # load from an .env file 
+)
 
 vetiver.deploy_rsconnect(
     connect_server = connect_server,

--- a/get-started/deploy.qmd
+++ b/get-started/deploy.qmd
@@ -78,62 +78,52 @@ You can interact with your vetiver API via automatically generated, detailed vis
 <script src="https://fast.wistia.com/embed/medias/w7p0op712v.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><div class="wistia_responsive_padding" style="padding:107.92% 0 0 0;position:relative;"><div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;"><div class="wistia_embed wistia_async_w7p0op712v videoFoam=true" style="height:100%;position:relative;width:100%"><div class="wistia_swatch" style="height:100%;left:0;opacity:0;overflow:hidden;position:absolute;top:0;transition:opacity 200ms;width:100%;"><img src="https://fast.wistia.com/embed/medias/w7p0op712v/swatch" style="filter:blur(5px);height:100%;object-fit:contain;width:100%;" alt="" aria-hidden="true" onload="this.parentNode.style.opacity=1;" /></div></div></div></div>
 <br>
 
-FastAPI and Plumber APIs such as these can be hosted in a variety of ways.
-For [RStudio Connect](https://posit.co/products/enterprise/connect/), you can deploy your versioned model with a single function, either `vetiver_deploy_rsconnect()` for R or `vetiver.deploy_rsconnect()` for Python. For more on these options, see the [Connect documentation for using vetiver](https://docs.posit.co/connect/user/vetiver/).
+FastAPI and Plumber APIs such as these can be hosted in a variety of ways. Let's walk through two options: deploying to Posit Connect or with Docker.
 
-For other hosting options, you can create a ready-to-go file for deployment.
+## Deploy to Connect
+
+For [Posit Connect](https://posit.co/products/enterprise/connect/), you can deploy your versioned model with a single function.
+
 
 ::: {.panel-tabset group="language"}
 ## R
 
 ```{r}
 #| eval: false
-vetiver_write_plumber(model_board, "cars_mpg")
+# authenticates via environment variables:
+vetiver_deploy_rsconnect(model_board, "user.name/cars_mpg")
 ```
-
-```{r}
-#| echo: false
-#| comment: ""
-docker_dir <- fs::path_real(tempdir())
-tmp_plumber <- fs::path(docker_dir, "plumber.R")
-vetiver_write_plumber(model_board, "cars_mpg", file = tmp_plumber, rsconnect = FALSE)
-cat(readr::read_lines(tmp_plumber), sep = "\n")
-```
-
-
 
 ## Python
 
 ```{python}
 #| eval: false
-app_file = vetiver.write_app(model_board, "cars_mpg")
+import os
+from dotenv import load_dotenv, find_dotenv
+import rsconnect
+
+load_dotenv(find_dotenv())
+rsc_key = os.getenv("API_KEY")
+rsc_url = os.getenv("RSC_URL")
+connect_server = RSConnectServer(url = rsc_url, api_key = rsc_key)
+
+vetiver.deploy_rsconnect(
+    connect_server = connect_server,
+    board = model_board,
+    pin_name = "user.name/cars_mpg",
+)
 ```
 
-```{python}
-#| echo: false
-#| comment: ""
-from vetiver import write_app
-import tempfile
-with tempfile.TemporaryDirectory() as temp:
-  tmp = temp + "app.py"
-  write_app(model_board, "cars_mpg", file=tmp)
-  contents = open(tmp).read()
-print(contents.replace(temp, "."))
-```
 :::
 
-In a real-world situation, you would see something like `board_rsconnect()` or `board_s3()` here instead of our temporary demo board.
+In this case, you probably want `model_board` to be a Connect pins board (`board_connect()`). For more on deploying to Connect, see the [Connect documentation for using vetiver](https://docs.posit.co/connect/user/vetiver/).
 
-::: callout-important
-Notice that the deployment is strongly linked to a specific version of the pinned model; if you pin another version of the model after you deploy your model, your deployed model will not be affected.
-:::
+## Prepare a Dockerfile
 
-## Generate a Dockerfile
-
-For deploying a vetiver API to infrastructure other than RStudio Connect, such as [Google Cloud Run](https://cloud.google.com/run/docs/deploying), [AWS](https://docs.aws.amazon.com/AmazonECS/latest/userguide/create-container-image.html), or [Azure](https://docs.microsoft.com/en-us/azure/container-instances/container-instances-quickstart), you likely will want to build a Docker container.
+For deploying a vetiver API to infrastructure other than Posit Connect, such as [Google Cloud Run](https://cloud.google.com/run/docs/deploying), [AWS](https://docs.aws.amazon.com/AmazonECS/latest/userguide/create-container-image.html), or [Azure](https://docs.microsoft.com/en-us/azure/container-instances/container-instances-quickstart), you likely will want to build a Docker container.
 
 ::: callout-note
-You can use any pins board with Docker, like `board_folder()` or `board_rsconnect()`, as long as your Docker container can authenticate to your pins board.
+You can use any pins board with Docker, like `board_folder()` or `board_connect()`, as long as your Docker container can authenticate to your pins board.
 :::
 
 ::: {.panel-tabset group="language"}
@@ -141,7 +131,7 @@ You can use any pins board with Docker, like `board_folder()` or `board_rsconnec
 
 ```{r}
 #| eval: false
-vetiver_write_docker(v)
+vetiver_prepare_docker(model_board, "cars_mpg")
 ```
 
 ```{r}
@@ -157,13 +147,13 @@ docker_contents <- gsub(paste0(docker_dir, "/"), "", docker_contents, fixed = TR
 cat(docker_contents, sep = "\n")
 ```
 
-When you run `vetiver_write_docker()`, you generate *two* files: the Dockerfile itself and [the `vetiver_renv.lock` file](https://rstudio.github.io/renv/articles/lockfile.html) to capture your model dependencies.
+When you run `vetiver_prepare_docker()`, you generate *three* files needed to build a Docker image: the Dockerfile itself, a Plumber file serving your REST API, and [the `vetiver_renv.lock` file](https://rstudio.github.io/renv/articles/lockfile.html) to capture your model dependencies.
 
 ## Python
 
 ```{python}
 #| eval: false
-vetiver.write_docker(app_file)
+vetiver.prepare_docker(model_board, "cars_mpg")
 ```
 
 ```{python}
@@ -182,7 +172,7 @@ print(contents.replace(temp, "."))
 
 ```
 
-To build the Docker image, you need *two* files: the Dockerfile itself generated via `vetiver_write_docker()` and [a `requirements.txt` file](https://pip.pypa.io/en/stable/reference/requirements-file-format/) to capture your model dependencies.
+When you run `vetiver.prepare_docker()`, you generate *three* files needed to build a Docker image: the Dockerfile itself, a FastAPI app file serving your REST API, and [a `requirements.txt` file](https://pip.pypa.io/en/stable/reference/requirements-file-format/) to capture your model dependencies.
 If you don't already have a requirements file for your project, `vetiver.load_pkgs()` will generate one for you, with the name `vetiver_requirements.txt`.
 :::
 
@@ -190,6 +180,8 @@ If you don't already have a requirements file for your project, `vetiver.load_pk
 -   When you build such a Docker container [with `docker build`](https://docs.docker.com/engine/reference/commandline/build/), all the packages needed to make a prediction with your model are installed into the container.
 
 -   When you run the Docker container, you can pass in environment variables (for authentication to your pins board, for example) with `docker run --env-file .Renviron`.
+
+-   Learn more about [deploying with Docker](https://vetiver.rstudio.com/learn-more/deploy-with-docker.html).
 :::
 
 ## Predict from your model endpoint
@@ -213,7 +205,7 @@ endpoint
 ```
 :::
 
-If such a deployed model endpoint is running via one process (either remotely on a server or locally, perhaps via [a background job in the RStudio IDE](https://docs.posit.co/ide/user/ide/guide/tools/jobs.html)), you can make predictions with that deployed model and new data in another, separate process[^1].
+If such a deployed model endpoint is running via one process (either remotely on a server or locally, perhaps via Docker or [a background job in the RStudio IDE](https://docs.posit.co/ide/user/ide/guide/tools/jobs.html)), you can make predictions with that deployed model and new data in another, separate process[^1].
 
 [^1]: Keep in mind that the R and Python models have different values for the decision tree hyperparameters.
 

--- a/get-started/index.qmd
+++ b/get-started/index.qmd
@@ -113,7 +113,7 @@ v
 ```{python}
 from vetiver import VetiverModel
 v = VetiverModel(car_mod, model_name = "cars_mpg", 
-                 ptype_data = mtcars.drop(columns="mpg"))
+                 prototype_data = mtcars.drop(columns="mpg"))
 v.description
 ```
 :::

--- a/get-started/version.qmd
+++ b/get-started/version.qmd
@@ -35,7 +35,7 @@ from sklearn import linear_model
 car_mod = linear_model.LinearRegression().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
                  
 v = VetiverModel(car_mod, model_name = "cars_mpg", 
-                 ptype_data = mtcars.drop(columns="mpg"))
+                 prototype_data = mtcars.drop(columns="mpg"))
 ```
 :::
 
@@ -105,7 +105,7 @@ from sklearn import tree
 car_mod = tree.DecisionTreeRegressor().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
 
 v = VetiverModel(car_mod, model_name = "cars_mpg", 
-                 ptype_data = mtcars.drop(columns="mpg"))
+                 prototype_data = mtcars.drop(columns="mpg"))
 vetiver_pin_write(model_board, v)
 ```
 :::

--- a/index.qmd
+++ b/index.qmd
@@ -49,7 +49,7 @@ from sklearn.linear_model import LinearRegression
 
 model = LinearRegression().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
 v = VetiverModel(model, model_name = "cars_linear", 
-                 ptype_data = mtcars.drop(columns="mpg"))
+                 prototype_data = mtcars.drop(columns="mpg"))
 v.description
 ```
 :::

--- a/learn-more/deploy-with-docker.qmd
+++ b/learn-more/deploy-with-docker.qmd
@@ -5,7 +5,7 @@ format:
     toc: true
 ---
 
-If you plan to bring vetiver to a public or private cloud outside of [RStudio Connect](https://posit.co/products/enterprise/connect/), [Docker](https://www.docker.com/) containers are a highly portable solution. Using vetiver makes Dockerfile creation easy by generating the files you need from your trained models.
+If you plan to bring vetiver to a public or private cloud rather than [Posit Connect](https://posit.co/products/enterprise/connect/), [Docker](https://www.docker.com/) containers are a highly portable solution. Using vetiver makes Dockerfile creation easy by generating the files you need from your trained models.
 
 ## Import data
 
@@ -94,7 +94,7 @@ import vetiver
 
 v = vetiver.VetiverModel(
     rf_pipe, 
-    ptype_data=X_train, 
+    prototype_data=X_train, 
     model_name = "superbowl_rf"
 )
 v.description
@@ -112,7 +112,7 @@ v
 
 ## Version your model
 
-We pin our vetiver model to a board to version it. We will also use this board later to create artifacts to run our Dockerfile. 
+We pin our vetiver model to a board to version it. We will also use this board later to create artifacts for our Dockerfile. 
 
 ::: {.panel-tabset group="language"}
 ## Python
@@ -136,53 +136,47 @@ vetiver.vetiver_pin_write(board, v)
 #| eval: false
 #| message: false
 library(pins)
-board <- board_rsconnect() # authenticates via environment variables
+board <- board_connect() # authenticates via environment variables
 vetiver_pin_write(board, v)
 ```
 :::
 
-Here we are using `board_rsconnect()`, but you can use other boards such as `board_s3()`. [Read more](https://vetiver.rstudio.com/get-started/version.html) about how to store and version your vetiver model.
+Here we are using `board_connect()`, but you can use other boards such as `board_s3()`. [Read more](https://vetiver.rstudio.com/get-started/version.html) about how to store and version your vetiver model.
 
-## Create API and Docker artifacts
+## Create Docker artifacts
 
-Next, let's create an `app.py` or `plumber.R` file. This file contains the [information to create a vetiver REST API](https://vetiver.rstudio.com/get-started/deploy.html#create-a-rest-api-for-deployment) and will be running inside your Docker container. 
+To build a Docker image that can serve your model, you need three artifacts:
 
-Once you have this file, vetiver can help you write a Dockerfile.
+- the Dockerfile itself,
+- a `requirements.txt` or `renv.lock` to capture your model dependencies, and
+- an `app.py` or `plumber.R` file containing the information to serve a vetiver REST API.
+
+You can create all the needed files with one function.
 
 ::: {.panel-tabset group="language"}
 ## Python
 
 ```{python}
 #| eval: false
-vetiver.write_app(
+vetiver.prepare_docker(
     board, 
-    "isabel.zimmerman/superbowl_rf", 
-    version = "20220901T144702Z-fd402"
+    "isabel.zimmerman/superbowl_rf",
+    version = "20220901T144702Z-fd402",
+    port = 8080
 )
-vetiver.write_docker()
 ```
 
-:::{.callout-note}
-You may need to edit the `app.py` file to load a `.env` file for authorization, if necessary.
-
-Docker also needs a requirements file. You can generate your own, or use `vetiver.load_pkgs()` to generate a file named `vetiver_req.txt` with the packages necessary for prediction.
-:::
 
 ## R
 
 ```{r}
 #| eval: false
-vetiver_write_plumber(board, "julia.silge/superbowl_rf")
-vetiver_write_docker(v, port=8080)
+vetiver_write_plumber(board, "julia.silge/superbowl_rf", port = 8080)
 ```
 
-:::{.callout-note}
-When you run `vetiver_write_docker()`, you generate *two* files: the Dockerfile itself and [the `vetiver_renv.lock` file](https://rstudio.github.io/renv/articles/lockfile.html) to capture your model dependencies.
 :::
 
-:::
-
-You have now created all the artifacts to run your Docker container!
+You have now created all the files needed to build your Docker image!
 
 ## Build and run your Dockerfile
 
@@ -196,7 +190,7 @@ docker build -t superbowlads .
 
 
 :::{.callout-tip}
-If you are on an ARM architecture locally and deploying an R model, use `--platform linux/amd64` for RSPM's fast installation of binaries.
+If you are on an ARM architecture locally and deploying an R model, use `--platform linux/amd64` for RSPM's fast installation of R package binaries.
 :::
 
 Now run! To authenticate to your board (to get the pinned vetiver model from, for example, RStudio Connect), pass in a file supplying environment variables.

--- a/learn-more/model-card.qmd
+++ b/learn-more/model-card.qmd
@@ -42,7 +42,7 @@ model_board = pins.board_temp(allow_pickle_read=True)
 
 model = LinearRegression().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
 v = vetiver.VetiverModel(model, model_name = "cars_linear", 
-                 ptype_data = mtcars.drop(columns="mpg"))
+                         prototype_data = mtcars.drop(columns="mpg"))
 
 vetiver.vetiver_pin_write(model_board, v)
 ```

--- a/vetiver.rstudio.com.Rproj
+++ b/vetiver.rstudio.com.Rproj
@@ -14,3 +14,7 @@ LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
Closes #51 

This PR updates to using `vetiver_prepare_docker()` / `vetiver.prepare_docker()` as well as the change to `prototype_data`.