### PR TITLE
Add callout for local boards with Docker

### DIFF
--- a/learn-more/deploy-with-docker.qmd
+++ b/learn-more/deploy-with-docker.qmd
@@ -145,7 +145,7 @@ Here we are using `board_connect()`, but you can use other boards such as `board
 
 ::: {.callout-note collapse="true"}
 ## Using local boards with Docker
-Local boards such as `board_folder()` will not be immediately available to Docker images created by vetiver. To make local boards available the Dockerfile must either [`COPY`](https://docs.docker.com/engine/reference/builder/#copy) the folder and model into the Docker container or mount the folder as a [`VOLUME`](https://docs.docker.com/engine/reference/builder/#volume). 
+Local boards such as `board_folder()` will not be immediately available to Docker images created by vetiver. To make local boards available, the Dockerfile must either [`COPY`](https://docs.docker.com/engine/reference/builder/#copy) the folder and model into the Docker container or mount the folder as a [`VOLUME`](https://docs.docker.com/engine/reference/builder/#volume). 
 :::
 
 ## Create Docker artifacts

--- a/learn-more/deploy-with-docker.qmd
+++ b/learn-more/deploy-with-docker.qmd
@@ -141,7 +141,12 @@ vetiver_pin_write(board, v)
 ```
 :::
 
-Here we are using `board_connect()`, but you can use other boards such as `board_s3()`. [Read more](https://vetiver.rstudio.com/get-started/version.html) about how to store and version your vetiver model.
+Here we are using `board_connect()`, but you can use other boards such as `board_s3()`. [Read more](https://vetiver.rstudio.com/get-started/version.html) about how to store and version your vetiver model. 
+
+::: {.callout-note collapse="true"}
+## Using local boards with Docker
+Local boards such as `board_folder()` will not be immediately available to Docker images created by vetiver. To make local boards available the Dockerfile must either [`COPY`](https://docs.docker.com/engine/reference/builder/#copy) the folder and model into the Docker container or mount the folder as a [`VOLUME`](https://docs.docker.com/engine/reference/builder/#volume). 
+:::
 
 ## Create Docker artifacts
 

--- a/learn-more/deploy-with-docker.qmd
+++ b/learn-more/deploy-with-docker.qmd
@@ -145,7 +145,9 @@ Here we are using `board_connect()`, but you can use other boards such as `board
 
 ::: {.callout-note collapse="true"}
 ## Using local boards with Docker
-Local boards such as `board_folder()` will not be immediately available to Docker images created by vetiver. To make local boards available, the Dockerfile must either [`COPY`](https://docs.docker.com/engine/reference/builder/#copy) the folder and model into the Docker container or mount the folder as a [`VOLUME`](https://docs.docker.com/engine/reference/builder/#volume). 
+Local boards such as `board_folder()` will not be immediately available to Docker images created by vetiver. We don't recommend that you store your model _inside_ your container, but (if appropriate to your use case) it is possible to edit the generated Dockerfile and [`COPY`](https://docs.docker.com/engine/reference/builder/#copy) the folder and model into the container. Alternatively, you can mount the folder as a [`VOLUME`](https://docs.docker.com/engine/reference/builder/#volume). 
+
+Learn more about why we recommend storing your versioned model binaries outside Docker containers [in this talk](https://youtu.be/HYvZ3HDJlf4).
 :::
 
 ## Create Docker artifacts


### PR DESCRIPTION
Closes https://github.com/rstudio/vetiver.rstudio.com/issues/69

This PR adds a collapsed callout to the Deploy with Docker article noting that local pin bords will not work with a Dockerfile without either copying the folder or mounting it as a volume. 