### PR TITLE
Fix `port` arg in Docker article

### DIFF
--- a/learn-more/deploy-with-docker.qmd
+++ b/learn-more/deploy-with-docker.qmd
@@ -178,7 +178,11 @@ vetiver.prepare_docker(
 
 ```{r}
 #| eval: false
-vetiver_prepare_docker(board, "julia.silge/superbowl_rf", port = 8080)
+vetiver_prepare_docker(
+    board, 
+    "julia.silge/superbowl_rf", 
+    docker_args = list(port = 8080)
+)
 ```
 
 :::


### PR DESCRIPTION
Closes #74 

Thanks for this report @EmilHvitfeldt! Missed this fix when we moved to our new Docker implementation.